### PR TITLE
useWindowDimensions

### DIFF
--- a/src/utils/customHooks/useWindowDimension.ts
+++ b/src/utils/customHooks/useWindowDimension.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+interface WindowDimensions {
+    width: number;
+    height: number;
+}
+
+const useWindowDimensions = (): WindowDimensions => {
+    const [windowDimensions, setWindowDimensions] = useState<WindowDimensions>({
+        width: window.innerWidth,
+        height: window.innerHeight,
+    });
+
+    useEffect(() => {
+        const handleResize = () => {
+            setWindowDimensions({
+                width: window.innerWidth,
+                height: window.innerHeight,
+            });
+        };
+
+        window.addEventListener('resize', handleResize);
+
+        return () => {
+            window.removeEventListener('resize', handleResize);
+        };
+    }, []);
+
+    return windowDimensions;
+};
+
+export default useWindowDimensions;


### PR DESCRIPTION

The useWindowDimensions hook in React provides the current width and height of the browser window, allowing you to create responsive and adaptable user interfaces.

One particular use case can be rendering content conditionally based on screen size